### PR TITLE
Environment Driven + Minecraft Lookup + Drone support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,50 @@
+---
+kind: pipeline
+name: linux-amd64
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: dryrun
+  pull: always
+  image: plugins/docker
+  settings:
+    dryrun: true
+    dockerfile: Dockerfile 
+    password:
+      from_secret: docker_password
+    repo:
+      from_secret: docker_repo
+    username:
+      from_secret: docker_username
+    purge: true
+  when:
+    event:
+    - pull_request
+
+- name: publish
+  image: plugins/docker
+  settings:
+    dockerfile: Dockerfile
+    password:
+      from_secret: docker_password
+    repo:
+      from_secret: docker_repo
+    username:
+      from_secret: docker_username
+    auto_tag: true
+    auto_tag_suffix: linux-amd64
+    purge: true
+  when:
+    exclude:
+    - pull_request
+
+trigger:
+  ref:
+  - refs/heads/master
+  - "refs/tags/**"
+  - "refs/pull/**"
+
+...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM alpine
+ENV OPENWEATHER_API_KEY = 1234
+ENV DISCORD_TOKEN = 1234
+
 RUN apk upgrade --no-cache \
   && apk add --no-cache \
     musl \
@@ -19,9 +22,7 @@ RUN cd /usr/bin \
   && ln -sf pip3 pip
 
 COPY . /app
-
 WORKDIR /app
 
 RUN pip install -r requirements.txt
-
 CMD python ./bot.py

--- a/README.md
+++ b/README.md
@@ -20,3 +20,21 @@ docker build --tag blbot .
 
 docker run -d --name blbot blbot
 ```
+
+
+# Compose Usage
+```
+version: '3'
+
+services:
+  blbot:
+    restart: always
+    image: /blbot:latest
+    container_name: blbot
+    environment:
+      - "OPENWEATHER_API_KEY=xxx"
+      - "DISCORD_TOKEN=xxx"
+
+    volumes:
+      - /data/blbot/quotes.db:/app/quotes.db
+```

--- a/bot.py
+++ b/bot.py
@@ -5,15 +5,20 @@ import os
 from pathlib import Path
 import json
 from discord.ext import commands
-
 from config import *
+import logging
+import sys
+
+token = os.environ.get('DISCORD_TOKEN')
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+
 
 description = '''A basic discord bot for my gaming group, the Bored Lunatics'''
 bot = commands.Bot(command_prefix='!', description=description)
 
 cwd = Path(__file__).parents[0]
 cwd = str(cwd)
-
 
 @bot.event
 async def on_ready():

--- a/cogs/minecraft.py
+++ b/cogs/minecraft.py
@@ -1,0 +1,24 @@
+from discord.ext import commands
+from mcstatus import MinecraftServer
+
+class minecraft(commands.Cog):
+  def __init__(self, bot):
+    self.bot = bot
+
+  @commands.Cog.listener()
+  async def on_ready(self):
+    print("Minecraft Lookup has been loaded\n-----")
+
+  @commands.command(aliases=['mc'])
+  async def minecraft(self, ctx, server: str):
+    """ Lookup players on a given host name."""
+    server = MinecraftServer.lookup(server)
+    status = server.status()
+    print(server.status())
+    await ctx.send(":cowboy:" + " The server has {0} players and replied in {1} ms".format(status.players.online, status.latency))
+  
+def setup(bot):
+  bot.add_cog(minecraft(bot))
+
+
+

--- a/cogs/weather.py
+++ b/cogs/weather.py
@@ -1,6 +1,9 @@
 from discord.ext import commands
 from config import *
 import requests
+import os
+
+OPENWEATHER_API_KEY = os.environ.get('OPENWEATHER_API_KEY')
 
 class weather(commands.Cog):
     def __init__(self, bot):
@@ -14,15 +17,14 @@ class weather(commands.Cog):
     @commands.command(name='Weather', aliases=['weather', 'w'])
     async def weather(self, ctx, arg, country='US'):
         city_name = arg + ',' + country
-        API_KEY = openweatherapikey
         api = "http://api.openweathermap.org/data/2.5/weather?units=imperial&q={city}&APPID={key}"
 
-        url = api.format(city=city_name, key=API_KEY)
+        url = api.format(city=city_name, key=OPENWEATHER_API_KEY)
         response = requests.get(url)
         js = response.json()
 
         if js["cod"] == '404':
-            value = "404, dodging a barf"
+            value = "Sorry partner, I can't find that location."
 
         else:
             value = "Temperature: {}\n{}, {}\nDescription:{}".format(js["main"]["temp"], js["name"],js["sys"]["country"], js["weather"][0]["main"])
@@ -31,4 +33,3 @@ class weather(commands.Cog):
 
 def setup(bot):
     bot.add_cog(weather(bot))
-

--- a/config.py
+++ b/config.py
@@ -1,4 +1,2 @@
-openweatherapikey = '<your-openweatherapi-key>'
-token = '<your-discord-bot-token>'
 dbtype = 'sqlite'
 dbfile = 'quotes.db'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ requests==2.22.0
 urllib3==1.25.3
 websockets==6.0
 yarl==1.3.0
-
+mcstatus


### PR DESCRIPTION
# Purpose
Create support for environment driven config for Discord and Open Weather API, add Minecraft functionality.



# Compose example
The following docker-compose assumes you're using the image I've built that's available on dockerhub.
```
version: '3'

services:
  blbot:
    restart: always
    image: fouts/blbot:latest
    container_name: blbot
    environment:
      - "OPENWEATHER_API_KEY=xxx"
      - "DISCORD_TOKEN=xxx"

    volumes:
      - /data/blbot/quotes.db:/app/quotes.db
```


# Drone support
Create .drone.yml to support drone ci. Purposely written so you can fill in your own dockerhub repo, username, and password without causing conflicts if you fork this repo